### PR TITLE
Add support to LLVM 13 via command line option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_policy(SET CMP0054 NEW)
 
 project(PARCOACH)
 message("This is PARCOACH")
-message("You need a version of LLVM from LLVM 9 to LLVM 12 to build this project")
+message("You need a version of LLVM from LLVM 9 to LLVM 13 to build this project")
 
 
 # c++11 for LLVM <= 9
@@ -15,7 +15,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(LLVM REQUIRED CONFIG)
 if ((LLVM_PACKAGE_VERSION VERSION_LESS 9) OR
     (LLVM_PACKAGE_VERSION VERSION_GREATER 12))
-  message(FATAL_ERROR "** Uncompatible LLVM version found: ${LLVM_PACKAGE_VERSION} **")
+  if (LLVM_PACKAGE_VERSION VERSION_GREATER 13)
+    message("NOTE: Using old Pass Manager for LLVM 13")
+    set(USE_OLD_PM -enable-new-pm=0)
+  else()
+    message(FATAL_ERROR "** Uncompatible LLVM version found: ${LLVM_PACKAGE_VERSION} **")
+  endif()
 endif()
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION} in ${LLVM_INSTALL_PREFIX}")

--- a/src/aSSA/CMakeLists.txt
+++ b/src/aSSA/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_llvm_library(aSSA MODULE
   	Collectives.cpp
   	CollList.cpp
-        DepGraph.cpp
+    DepGraph.cpp
 	DepGraphDCF.cpp
 	ExtInfo.cpp
 	MemoryRegion.cpp

--- a/src/aSSA/DepGraphDCF.cpp
+++ b/src/aSSA/DepGraphDCF.cpp
@@ -826,7 +826,7 @@ void DepGraphDCF::toDot(string filename) {
   double t1 = gettime();
 
   error_code EC;
-  raw_fd_ostream stream(filename, EC, sys::fs::F_Text);
+  raw_fd_ostream stream(filename, EC, sys::fs::OF_Text);
 
   stream << "digraph F {\n";
   stream << "compound=true;\n";
@@ -1601,7 +1601,7 @@ void DepGraphDCF::dotTaintPath(const Value *v, string filename,
   assert(stop);
 
   error_code EC;
-  raw_fd_ostream stream(filename, EC, sys::fs::F_Text);
+  raw_fd_ostream stream(filename, EC, sys::fs::OF_Text);
 
   stream << "digraph F {\n";
   stream << "compound=true;\n";
@@ -1777,7 +1777,7 @@ void DepGraphDCF::dotTaintPath(const Value *v, string filename,
   if (getDebugTrace(debugLocs, trace, collective)) {
     string tracefilename = filename + ".trace";
     errs() << "Writing '" << tracefilename << "' ...\n";
-    raw_fd_ostream tracestream(tracefilename, EC, sys::fs::F_Text);
+    raw_fd_ostream tracestream(tracefilename, EC, sys::fs::OF_Text);
     tracestream << trace;
   }
 }

--- a/src/aSSA/MemorySSA.cpp
+++ b/src/aSSA/MemorySSA.cpp
@@ -598,7 +598,7 @@ void MemorySSA::dumpMSSA(const llvm::Function *F) {
   filename.append("-assa.ll");
   errs() << "Writing '" << filename << "' ...\n";
   error_code EC;
-  raw_fd_ostream stream(filename, EC, sys::fs::F_Text);
+  raw_fd_ostream stream(filename, EC, sys::fs::OF_Text);
 
   // Function header
   stream << "define " << *F->getReturnType() << " @" << F->getName().str() << "(";

--- a/src/aSSA/andersen/ConstraintOptimize.cpp
+++ b/src/aSSA/andersen/ConstraintOptimize.cpp
@@ -149,7 +149,7 @@ protected:
 	void writePredecessorGraphToFile() const
 	{
 		std::error_code errInfo;
-		ToolOutputFile outFile("dots/pred.dot", errInfo, sys::fs::F_Text);
+		ToolOutputFile outFile("dots/pred.dot", errInfo, sys::fs::OF_Text);
 		if (errInfo)
 		{
 			errs() << errInfo.message() << '\n';

--- a/src/aSSA/parcoach.in
+++ b/src/aSSA/parcoach.in
@@ -1,2 +1,2 @@
 #!/bin/sh
-@LLVM_TOOLS_BINARY_DIR@/opt -load @PARCOACH_LIB@ -parcoach  "$@"
+@LLVM_TOOLS_BINARY_DIR@/opt @USE_OLD_PM@ -load @PARCOACH_LIB@ -parcoach "$@"


### PR DESCRIPTION
This PR allows compiling and running Parcoach on systems using LLVM 13 using the old Pass Manager as a transitory measure.
All tests now pass again.

Note that only compatibility with LLVM 12 and 13 was tested. If these changes fail on any version older than that, I am open to adding compatibility as well if requested. It was left out for feedback on the current approach.